### PR TITLE
Only warn when the BSP socket gets closed

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -77,6 +77,7 @@ object BspServer {
       val server = new BloopLanguageServer(messages, client, provider.services, ioScheduler, bspLogger)
       // FORMAT: ON
 
+      def warn(msg: String): Unit = provider.stateAfterExecution.logger.warn(msg)
       def error(msg: String): Unit = provider.stateAfterExecution.logger.error(msg)
 
       /* This implementation of starting a server relies on two observables:
@@ -129,7 +130,7 @@ object BspServer {
           }
 
           try {
-            if (cancelled) error(s"BSP server cancelled, closing socket...")
+            if (cancelled) warn(s"BSP server cancelled, closing socket...")
             else result.foreach(t => error(s"BSP server stopped by ${t.getMessage}"))
             cancelable.cancel()
             server.cancelAllRequests()

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -353,6 +353,11 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
   }
 
   test("deduplication doesn't work if project definition changes") {
+    TestUtil.retry() {
+      deduplicationIfProjectDefinitionChangesTest()
+    }
+  }
+  def deduplicationIfProjectDefinitionChangesTest(): Unit = {
     val logger = new RecordingLogger(ansiCodesSupported = false)
     BuildUtil.testSlowBuild(logger) { build =>
       val state = new TestState(build.state)


### PR DESCRIPTION
So that by default, nothing get printed for that.