### PR TITLE
Alias 'exit' to 'ng-stop'.

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -186,6 +186,13 @@ object Bloop {
         classOf[Bloop]
       )
     )
+    aliasManager.addAlias(
+      new Alias(
+        "ng-stop",
+        "Kill the bloop server.",
+        classOf[Bloop]
+      )
+    )
 
     // Register the default entrypoint in case the user doesn't use the right alias
     server.setDefaultNailClass(classOf[Cli])


### PR DESCRIPTION
It has a special behavior in snailgun

https://github.com/jvican/snailgun/blob/1c6ba5cfbd948aaf055a729cc481d6292c661f7a/core/src/main/scala/snailgun/protocol/Protocol.scala#L113