### PR TITLE
Don't trap unexpected compilation errors

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -294,6 +294,7 @@ object CompileTask {
               case FinalNormalCompileResult.HasException(project, err) =>
                 val errMsg = err.fold(identity, _.getMessage)
                 rawLogger.error(s"Unexpected error when compiling ${project.name}: '$errMsg'")
+                err.foreach(_.printStackTrace(System.err))
                 err.foreach(rawLogger.trace(_))
               case _ => () // Do nothing when the final compilation result is not an actual error
             }


### PR DESCRIPTION
This should allow to get the exception stack trace in 'scala-cli bloop output' when getting errors like
    Unexpected error when compiling project_…: 'null'