### PR TITLE
Publish backend and frontend test JARs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ lazy val backend = project
       Keys.scalaOrganization
     ),
     buildInfoObject := "BloopScalaInfo",
+    Test / publishArtifact := true,
     libraryDependencies ++= List(
       Dependencies.nailgun,
       Dependencies.scalazCore,
@@ -165,6 +166,7 @@ lazy val frontend: Project = project
     (Test / fork) := true,
     (IntegrationTest / run / fork) := true,
     (test / parallelExecution) := false,
+    Test / publishArtifact := true,
     libraryDependencies ++= List(
       Dependencies.jsoniterMacros % Provided,
       Dependencies.caseApp,


### PR DESCRIPTION
That should allow to experiment more with splitting the upstream Bloop repo (whose `launcherTest` module needs on the frontend tests)