### PR TITLE
Fix resolving nativeBridge04 and jsBridge1 artifacts id

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -260,8 +260,8 @@ class Frontend(val crossScalaVersion: String) extends BloopCrossSbtModule with P
          |  def bspVersion = "${Dependencies.bsp4s.dep.version}"
          |  def zincVersion = "${Dependencies.zinc.dep.version}"
          |  def snailgunVersion = "0.4.1-sc2"
-         |  def nativeBridge04 = "${bridges.`scala-native-04`().artifactId}"
-         |  def jsBridge1 = "${bridges.`scalajs-1`().artifactId}"
+         |  def nativeBridge04 = "${bridges.`scala-native-04`().artifactId()}"
+         |  def jsBridge1 = "${bridges.`scalajs-1`().artifactId()}"
          |}
          |""".stripMargin
     if (!os.isFile(dest) || os.read(dest) != code)


### PR DESCRIPTION
Now it generates the correct artifactId for the dependency:

```
  def nativeBridge04 = "bloop-native-bridge-0-4_2.12"
  def jsBridge1 = "bloop-js-bridge-1_2.12"
```

Previously, it was generating:
```
  def nativeBridge04 = "bridges.scala-native-04[2.12.17].artifactId"
  def jsBridge1 = "bridges.scalajs-1[2.12.17].artifactId"
```