### PR TITLE
chore: Adjust Mill build file to fix Bloop compilation

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -373,7 +373,9 @@ object bridges extends Module {
   class Scalajs1(val crossScalaVersion: String) extends BloopCrossSbtModule with PublishModule {
     def artifactName = "bloop-js-bridge-1"
     def compileModuleDeps = super.compileModuleDeps ++ Seq(
-      frontend()
+      frontend(),
+      shared(),
+      backend()
     )
     def compileIvyDeps = super.compileIvyDeps() ++ Agg(
       Dependencies.scalaJsLinker1,
@@ -417,7 +419,9 @@ object bridges extends Module {
     def sources = T.sources(updateSources(super.sources()))
 
     def compileModuleDeps = super.compileModuleDeps ++ Seq(
-      frontend()
+      frontend(),
+      shared(),
+      backend()
     )
     def compileIvyDeps = super.compileIvyDeps() ++ Agg(
       Dependencies.scalaNativeTools04


### PR DESCRIPTION
Previously, if importing build as Bloop we would not get proper classpath for bridge modules as they would be missing transitive classes directories. This is probably a bug in mill bloop plugin, but I am not sure we want to dig in there currently. Now, I added explicit depndency on those moduls which seems to have fixed compilation.