### PR TITLE
Fix JDK version parsing for EA builds

### DIFF
--- a/bloop-rifle/src/bloop/rifle/BloopVersion.scala
+++ b/bloop-rifle/src/bloop/rifle/BloopVersion.scala
@@ -1,7 +1,8 @@
 package bloop.rifle
 case class BloopVersion(raw: String) {
   def isOlderThan(other: BloopVersion) = {
-    val bloopVRegex = "([0-9]+).([0-9]+)[.]([0-9]+)[-]?([0-9]+)?".r
+    val bloopVRegex = "([0-9]+).([0-9]+)[.]([0-9]+)[-]?[a-z]*[-]?([0-9]+)?".r
+    // https://regex101.com/r/YOZsOH/1
     def unwrapVersionString(v: String) =
       List(1, 2, 3, 4).map(bloopVRegex.findAllIn(v).group(_)).map(x =>
         if (x != null) x.toInt else 0

--- a/bloop-rifle/src/bloop/rifle/VersionUtil.scala
+++ b/bloop-rifle/src/bloop/rifle/VersionUtil.scala
@@ -30,7 +30,8 @@ object VersionUtil {
   def parseBloopAbout(stdoutFromBloopAbout: String): Option[BloopRifle.BloopServerRuntimeInfo] = {
 
     val bloopVersionRegex = "bloop v(.*)\\s".r
-    val bloopJvmRegex     = "Running on Java ... v([0-9._A-Za-z]+) [(](.*)[)]".r
+    val bloopJvmRegex     = "Running on Java ... v([0-9._A-Za-z\\-]+) [(](.*)[)]".r
+    // https://regex101.com/r/lT624X/1
 
     for {
       bloopVersion    <- bloopVersionRegex.findFirstMatchIn(stdoutFromBloopAbout).map(_.group(1))

--- a/bloop-rifle/test/src/bloop/rifle/ParsingTests.scala
+++ b/bloop-rifle/test/src/bloop/rifle/ParsingTests.scala
@@ -19,6 +19,7 @@ class ParsingTests extends munit.FunSuite {
     expect(!("1.4.9".v isOlderThan "1.4.9".v))
     expect("1.4.10-2".v isOlderThan "1.4.10-4".v)
     expect("1.4.10-2-abc".v isOlderThan "1.4.10-4-def".v)
+    expect("1.5.6-sc-2".v isOlderThan "1.5.6-sc-4".v)
   }
 
   test("jvm release parsing test") {
@@ -29,6 +30,8 @@ class ParsingTests extends munit.FunSuite {
     expect("9".j == Some(9))
     expect("14".j == Some(14))
     expect("17".j == Some(17))
+    expect("17.0.9-ea".j == Some(17))
+    expect("21-ea".j == Some(21))
   }
 
   test("parse jvm version") {
@@ -36,6 +39,8 @@ class ParsingTests extends munit.FunSuite {
     expect("""openjdk version "9" """.jv == Some(9))
     expect("""openjdk version "11.0.11" 2021-04-20 """.jv == Some(11))
     expect("""openjdk version "16" 2021-03-16 """.jv == Some(16))
+    expect("""openjdk version "17.0.9-ea" 2023-10-17 """.jv == Some(17))
+    expect("""openjdk version "21-ea" 2023-09-19 """.jv == Some(21))
   }
 
   val jreBloopOutput =
@@ -55,6 +60,14 @@ class ParsingTests extends munit.FunSuite {
        |  -> Supports debugging user code, Java Debug Interface (JDI) is available.
        |Maintained by the Scala Center and the community.""".stripMargin
 
+  val jdkBloopOutputEA =
+    """|bloop v1.5.6-sc-4
+       |
+       |Using Scala v2.12.17 and Zinc v1.8.0
+       |Running on Java JDK v17.0.9-ea (/usr/lib/jvm/java-17-openjdk-amd64)
+       |  -> Supports debugging user code, Java Debug Interface (JDI) is available.
+       |Maintained by the Scala Center and the community.""".stripMargin
+
   test("parse jre bloop about") {
     expect(jreBloopOutput.p == Some(BloopRifle.BloopServerRuntimeInfo(
       BloopVersion("1.4.11"),
@@ -68,6 +81,14 @@ class ParsingTests extends munit.FunSuite {
       BloopVersion("1.4.11"),
       16,
       "/usr/lib/jvm/java-16-openjdk-amd64"
+    )))
+  }
+
+  test("parse jdk bloop about (EA JDK)") {
+    expect(jdkBloopOutputEA.p == Some(BloopRifle.BloopServerRuntimeInfo(
+      BloopVersion("1.5.6-sc-4"),
+      17,
+      "/usr/lib/jvm/java-17-openjdk-amd64"
     )))
   }
 


### PR DESCRIPTION
This would fix an issues I've run into surfacing like:
```
me@m1:~/projects/bleep$ bleep compile
📗 bootstrapped in 10 ms
📙 Your build uses the default system JVM, which can change outside the build. For stable builds over time, let bleep manage your chosen JVM by adding it to bleep.yaml
📗 bloop-rifle: Starting compilation server
📕 command failed unexpectedly java.lang.RuntimeException: Fatal error, could not spawn Bloop: failed to parse output: 'bloop v1.5.6-sc-4

Using Scala v2.12.17 and Zinc v1.8.0
Running on Java JDK v17.0.9-ea (/usr/lib/jvm/java-17-openjdk-amd64)
  -> Supports debugging user code, Java Debug Interface (JDI) is available.
Maintained by the Scala Center and the community.
'
        at scala.build.bloop.BloopServer$.ensureBloopRunning$$anonfun$2(BloopServer.scala:114)
        at scala.util.Either.fold(Either.scala:190)
        at scala.build.bloop.BloopServer$.ensureBloopRunning(BloopServer.scala:114)
        at scala.build.bloop.BloopServer$.bsp(BloopServer.scala:154)
        at scala.build.bloop.BloopServer$.buildServer(BloopServer.scala:184)
        at bleep.BleepCommandRemote.run(BleepCommandRemote.scala:49)
        at bleep.Main$.$anonfun$41$$anonfun$1$$anonfun$2(Main.scala:482)
        at bleep.Main$.run$$anonfun$1(Main.scala:546)
        at scala.util.Try$.apply(Try.scala:210)
        at bleep.Main$.run(Main.scala:546)
        at bleep.Main$.$anonfun$41$$anonfun$1(Main.scala:482)
        at bleep.logging.TypedLoggerResource$.bleep$logging$TypedLoggerResource$Ops$$anon$4$$_$use$$anonfun$4(TypedLoggerResource.scala:41)
        at bleep.logging.TypedLoggerResource$Ops$$anon$1.use$$anonfun$1(TypedLoggerResource.scala:20)
        at bleep.logging.TypedLoggerResource$.bleep$logging$TypedLoggerResource$Ops$$anon$3$$_$use$$anonfun$3$$anonfun$1(TypedLoggerResource.scala:34)
        at bleep.logging.TypedLoggerResource$$anon$6.use(TypedLoggerResource.scala:56)
        at bleep.logging.TypedLoggerResource$Ops$$anon$3.use$$anonfun$3(TypedLoggerResource.scala:34)
        at bleep.logging.TypedLoggerResource$Ops$$anon$1.use$$anonfun$1(TypedLoggerResource.scala:20)
        at bleep.logging.TypedLoggerResource$$anon$7.use(TypedLoggerResource.scala:67)
        at bleep.logging.TypedLoggerResource$Ops$$anon$1.use(TypedLoggerResource.scala:20)
        at bleep.logging.TypedLoggerResource$Ops$$anon$3.use(TypedLoggerResource.scala:36)
        at bleep.logging.TypedLoggerResource$Ops$$anon$1.use(TypedLoggerResource.scala:20)
        at bleep.logging.TypedLoggerResource$Ops$$anon$4.use(TypedLoggerResource.scala:41)
        at bleep.Main$.$anonfun$41(Main.scala:484)
        at bleep.ExitCode.andThen(ExitCode.scala:6)
        at bleep.Main$.main(Main.scala:486)
        at bleep.Main.main(Main.scala)
```

Could this be released as something like `io.github.alexarchambault.bleep::bloop-rifle:1.5.10-sc-2`?

I have also prepared a patch for `bleep` incorporating this changed dep. I'm going to create a PR there as a next step.