### PR TITLE
Update bsp4j to 2.1.0-M6

### DIFF
--- a/bloop-rifle/src/bloop/rifle/BloopServer.scala
+++ b/bloop-rifle/src/bloop/rifle/BloopServer.scala
@@ -201,7 +201,6 @@ object BloopServer {
       .setLocalService(buildClient)
       .create()
     val server = launcher.getRemoteProxy
-    buildClient.onConnectWithServer(server)
 
     val f = launcher.startListening()
 

--- a/build.sc
+++ b/build.sc
@@ -30,7 +30,7 @@ object Dependencies {
   def asmUtil           = ivy"org.ow2.asm:asm-util:$asmVersion"
   def bloopConfig       = ivy"ch.epfl.scala::bloop-config:1.5.5"
   def brave             = ivy"io.zipkin.brave:brave:5.16.0"
-  def bsp4j             = ivy"ch.epfl.scala:bsp4j:2.1.0-M5"
+  def bsp4j             = ivy"ch.epfl.scala:bsp4j:2.1.0-M6"
   def bsp4s             = ivy"ch.epfl.scala::bsp4s:2.1.0-M5"
   def caseApp           = ivy"com.github.alexarchambault::case-app:2.0.6"
   def caseApp21         = ivy"com.github.alexarchambault::case-app:2.1.0-M15"


### PR DESCRIPTION
I removed line with:
```
buildClient.onConnectWithServer(server)
``` 
because it was removed from BSP and it wasn't a proper json-rpc notification. https://github.com/build-server-protocol/build-server-protocol/pull/555
