### PR TITLE
bugfix: Handle NoClassDefFoundError coming from the compiler

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -137,6 +137,10 @@ final class BloopHighLevelCompiler(
               val msg = "Encountered a StackOverflowError coming from the compiler. You might need to restart your Bloop build server"
               logger.error(s"${msg}:\n${t.getStackTrace().mkString("\n")}")
               throw new CompileFailed(new Array(0), msg, new Array(0), t)
+            case t: NoClassDefFoundError =>
+              val msg = "Encountered a NoClassDefFoundError coming from the compiler. You might need to clean compile your workspace"
+              logger.error(s"${msg}:\n${t.getStackTrace().mkString("\n")}")
+              throw new CompileFailed(new Array(0), msg, new Array(0), t)
             case NonFatal(t) =>
               // If scala compilation happens, complete the java promise so that it doesn't block
               JavaCompleted.tryFailure(t)


### PR DESCRIPTION
It seems due to some incremental compilation errors (possibly), an exception can be thrown from inlining and if we don't handle it, we will never finish the compilation:

```
java.lang.NoClassDefFoundError: besom/internal/Context
    at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
    at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3402)
    at java.base/java.lang.Class.getMethodsRecursive(Class.java:3543)
    at java.base/java.lang.Class.getMethod0(Class.java:3529)
    at java.base/java.lang.Class.getMethod(Class.java:2225)
    at dotty.tools.dotc.quoted.Interpreter.getMethod(Interpreter.scala:221)
    at dotty.tools.dotc.quoted.Interpreter.interpretedStaticMethodCall(Interpreter.scala:173)
    at dotty.tools.dotc.quoted.Interpreter.interpretTree(Interpreter.scala:76)
    at dotty.tools.dotc.transform.Splicer$SpliceInterpreter.interpretTree(Splicer.scala:247)
    at dotty.tools.dotc.quoted.Interpreter.interpretTree$$anonfun$2(Interpreter.scala:95)
    at dotty.tools.dotc.transform.Splicer$.$anonfun$2(Splicer.scala:60)
    at scala.Option.fold(Option.scala:263)
    at dotty.tools.dotc.transform.Splicer$.splice(Splicer.scala:60)
    at dotty.tools.dotc.inlines.Inliner.dotty$tools$dotc$inlines$Inliner$$expandMacro(Inliner.scala:1042)
    at dotty.tools.dotc.inlines.Inliner$InlineTyper.typedApply(Inliner.scala:818)
    at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:2928)
    at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2991)
    at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:126)
    at dotty.tools.dotc.inlines.Inliner$InlineTyper.typedUnadapted(Inliner.scala:904)
    at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3058)
    at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3062)
    at dotty.tools.dotc.typer.ReTyper.typedTyped(ReTyper.scala:64)
    at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:2933)
    at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2991)
    at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:126)
    at dotty.tools.dotc.inlines.Inliner$InlineTyper.typedUnadapted(Inliner.scala:904)
    at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3058)
    at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3055)
    at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3062)
    at dotty.tools.dotc.inlines.Inliner.inlined(Inliner.scala:671)
    at dotty.tools.dotc.inlines.Inlines$InlineCall.expand(Inlines.scala:444)
    at dotty.tools.dotc.inlines.Inlines$.inlineCall(Inlines.scala:151)
    at dotty.tools.dotc.transform.Inlining$InliningTreeMap.transform(Inlining.scala:99)
    at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transform(Trees.scala:1478)
    at dotty.tools.dotc.ast.TreeMapWithImplicits.transform(TreeMapWithImplicits.scala:73)
    at dotty.tools.dotc.transform.Inlining$InliningTreeMap.transform(Inlining.scala:93)
    at dotty.tools.dotc.ast.tpd$TreeMapWithPreciseStatContexts.loop$2(tpd.scala:1228)
    at dotty.tools.dotc.ast.tpd$TreeMapWithPreciseStatContexts.transformStats(tpd.scala:1228)
    at dotty.tools.dotc.ast.tpd$TreeMapWithPreciseStatContexts.transformStats(tpd.scala:1230)
    at dotty.tools.dotc.ast.TreeMapWithImplicits.transform(TreeMapWithImplicits.scala:64)
    at dotty.tools.dotc.transform.Inlining$InliningTreeMap.transform(Inlining.scala:115)
    at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transform(Trees.scala:1483)
    at dotty.tools.dotc.ast.TreeMapWithImplicits.transform(TreeMapWithImplicits.scala:73)
    at dotty.tools.dotc.transform.Inlining$InliningTreeMap.transform(Inlining.scala:93)
    at dotty.tools.dotc.ast.tpd$TreeMapWithPreciseStatContexts.loop$2(tpd.scala:1228)
    at dotty.tools.dotc.ast.tpd$TreeMapWithPreciseStatContexts.transformStats(tpd.scala:1228)
    at dotty.tools.dotc.ast.tpd$TreeMapWithPreciseStatContexts.transformStats(tpd.scala:1230)
    at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transform(Trees.scala:1491)
    at dotty.tools.dotc.ast.TreeMapWithImplicits.transform(TreeMapWithImplicits.scala:73)
    at dotty.tools.dotc.transform.Inlining$InliningTreeMap.transform(Inlining.scala:105)
    at dotty.tools.dotc.transform.Inlining$$anon$2.transform(Inlining.scala:62)
    at dotty.tools.dotc.transform.MacroTransform.run(MacroTransform.scala:18)
    at dotty.tools.dotc.transform.Inlining.run(Inlining.scala:34)
    at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:324)
    at scala.collection.immutable.List.map(List.scala:250)
    at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:328)
    at dotty.tools.dotc.transform.Inlining.runOn(Inlining.scala:38)
    at dotty.tools.dotc.Run.runPhases$1$$anonfun$1(Run.scala:247)
    at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
    at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
    at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1321)
    at dotty.tools.dotc.Run.runPhases$1(Run.scala:263)
    at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:271)
    at dotty.tools.dotc.Run.compileUnits$$anonfun$adapted$1(Run.scala:280)
    at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:67)
    at dotty.tools.dotc.Run.compileUnits(Run.scala:280)
    at dotty.tools.dotc.Run.compileSources(Run.scala:195)
    at dotty.tools.dotc.Run.compile(Run.scala:179)
    at dotty.tools.dotc.Driver.doCompile(Driver.scala:35)
    at dotty.tools.xsbt.CompilerBridgeDriver.run(CompilerBridgeDriver.java:88)
    at dotty.tools.xsbt.CompilerBridge.run(CompilerBridge.java:22)
    at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:91)
    at sbt.internal.inc.bloop.internal.BloopHighLevelCompiler.compileSources$1(BloopHighLevelCompiler.scala:133)
    at sbt.internal.inc.bloop.internal.BloopHighLevelCompiler.$anonfun$compile$7(BloopHighLevelCompiler.scala:155)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    at sbt.internal.inc.bloop.internal.BloopHighLevelCompiler.$anonfun$compile$1(BloopHighLevelCompiler.scala:71)
    at bloop.tracing.BraveTracer.traceInternal(BraveTracer.scala:67)
    at bloop.tracing.BraveTracer.trace(BraveTracer.scala:41)
    at sbt.internal.inc.bloop.internal.BloopHighLevelCompiler.timed$1(BloopHighLevelCompiler.scala:70)
    at sbt.internal.inc.bloop.internal.BloopHighLevelCompiler.$anonfun$compile$6(BloopHighLevelCompiler.scala:155)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:81)
    at monix.eval.internal.TaskRestartCallback.syncOnSuccess(TaskRestartCallback.scala:101)
    at monix.eval.internal.TaskRestartCallback.onSuccess(TaskRestartCallback.scala:74)
    at monix.eval.internal.TaskExecuteOn$AsyncRegister$$anon$1.run(TaskExecuteOn.scala:71)
    at monix.execution.internal.InterceptRunnable.run(InterceptRunnable.scala:27)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: besom.internal.Context
    at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:440)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:587)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
    ... 89 more
```